### PR TITLE
fix: add metrics-server RBAC permissions and sampler logging

### DIFF
--- a/charts/optipod/templates/rbac.yaml
+++ b/charts/optipod/templates/rbac.yaml
@@ -75,6 +75,15 @@ rules:
   verbs:
   - create
   - patch
+# Metrics Server API (for metrics-server provider)
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
 ---
 # ClusterRoleBinding for controller manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -307,11 +307,17 @@ func main() {
 		Sampler() *metrics.MetricsServerSampler
 	}); ok {
 		if sampler := samplerProvider.Sampler(); sampler != nil {
+			setupLog.Info("Registering metrics-server sampler with manager")
 			if err := mgr.Add(sampler); err != nil {
 				setupLog.Error(err, "unable to register metrics-server sampler")
 				os.Exit(1)
 			}
+			setupLog.Info("Metrics-server sampler registered successfully")
+		} else {
+			setupLog.Info("Metrics-server sampler is nil, skipping registration")
 		}
+	} else {
+		setupLog.Info("Metrics provider does not support sampling", "provider", operatorConfig.GetMetricsProvider())
 	}
 
 	// Initialize recommendation engine

--- a/internal/metrics/sampler.go
+++ b/internal/metrics/sampler.go
@@ -25,7 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var log = logf.Log.WithName("metrics-sampler")
 
 // TargetKey identifies a workload container across pod restarts.
 type TargetKey struct {
@@ -249,12 +252,14 @@ func (s *MetricsServerSampler) RegisterTarget(key TargetKey, podName string) {
 
 // Start begins the sampling loop. It stops when the context is cancelled.
 func (s *MetricsServerSampler) Start(ctx context.Context) error {
+	log.Info("Starting metrics-server sampler", "interval", s.interval, "targetTTL", s.targetTTL)
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			log.Info("Stopping metrics-server sampler")
 			return nil
 		case <-ticker.C:
 			s.sampleOnce(ctx)
@@ -264,14 +269,35 @@ func (s *MetricsServerSampler) Start(ctx context.Context) error {
 
 func (s *MetricsServerSampler) sampleOnce(ctx context.Context) {
 	targets := s.store.listTargets()
+
+	if len(targets) == 0 {
+		log.V(1).Info("No targets registered, skipping sampling")
+		return
+	}
+
+	log.Info("Sampling metrics", "targetCount", len(targets))
+
+	successCount := 0
+	errorCount := 0
+
 	for _, target := range targets {
 		podMetrics, err := s.metricsClientset.MetricsV1beta1().PodMetricses(target.key.Namespace).Get(ctx, target.podName, metav1.GetOptions{})
 		if err != nil {
+			log.Error(err, "Failed to get pod metrics",
+				"namespace", target.key.Namespace,
+				"pod", target.podName,
+				"container", target.key.Container)
+			errorCount++
 			continue
 		}
 
 		containerMetrics := findContainerMetrics(podMetrics, target.key.Container)
 		if containerMetrics == nil {
+			log.Error(nil, "Container not found in pod metrics",
+				"namespace", target.key.Namespace,
+				"pod", target.podName,
+				"container", target.key.Container)
+			errorCount++
 			continue
 		}
 
@@ -281,7 +307,20 @@ func (s *MetricsServerSampler) sampleOnce(ctx context.Context) {
 			MemoryByte: containerMetrics.Usage.Memory().Value(),
 		}
 		s.store.appendSample(target.key, sample)
+		successCount++
+
+		log.V(1).Info("Collected sample",
+			"namespace", target.key.Namespace,
+			"workload", target.key.WorkloadName,
+			"container", target.key.Container,
+			"cpu", fmt.Sprintf("%dm", sample.CPUMilli),
+			"memory", fmt.Sprintf("%dMi", sample.MemoryByte/(1024*1024)))
 	}
+
+	log.Info("Sampling complete",
+		"targets", len(targets),
+		"success", successCount,
+		"errors", errorCount)
 
 	s.store.evictStaleTargets(s.targetTTL)
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue where OptiPod couldn't collect metrics from metrics-server due to missing RBAC permissions and adds comprehensive logging for better observability.

## Changes

### RBAC Permissions
- Added  API group permissions to the controller's ClusterRole
- Grants  and  verbs for  and  resources in the metrics API group
- Enables OptiPod to query metrics-server for pod resource usage

### Logging Enhancements
- Added comprehensive logging to the metrics-server sampler
- Logs sampler startup with interval and TTL configuration
- Logs each sampling cycle with target count, success count, and error count
- Logs individual sample collection with CPU/memory values at V(1) verbosity level
- Added sampler registration logging in main.go

## Testing

Tested in kind cluster with metrics-server:
- Verified RBAC permissions allow metrics collection
- Confirmed sampler successfully collects metrics every 5 minutes
- Observed detailed logging output showing sampling progress
- Sample collection working: 7+ samples collected successfully

## Related Issues

Fixes the metrics-server integration issue where OptiPod was unable to access metrics due to insufficient RBAC permissions.

## Checklist

- [x] CI checks pass locally
- [x] Code formatted with gofmt and goimports
- [x] Tested in kind cluster with metrics-server
- [x] Logging provides useful observability
- [x] RBAC permissions follow least-privilege principle