### PR TITLE
docs: fix Phase 2 reference documentation

### DIFF
--- a/website/src/content/docs/docs/concepts/operational-modes.mdx
+++ b/website/src/content/docs/docs/concepts/operational-modes.mdx
@@ -15,18 +15,18 @@ OptiPod supports three operational modes that control how recommendations are ge
 
 ## Recommend Mode
 
-**Default mode.** OptiPod analyzes workloads and stores recommendations as annotations, but doesn't apply them automatically.
+**Default and safest mode.** OptiPod analyzes workloads and stores recommendations as annotations, but doesn't apply them automatically.
 
 ### How It Works
 
-1. OptiPod analyzes metrics for labeled workloads
-2. Generates recommendations based on usage patterns
-3. Stores recommendations as annotations on the workload
-4. You review and decide whether to apply changes
+1. OptiPod analyzes metrics for workloads matching policy selectors
+2. Generates recommendations based on usage patterns and policy configuration
+3. Stores recommendations as annotations on the workload metadata
+4. You review and decide whether to apply changes manually
 
 ### Recommendation Format
 
-Recommendations appear as annotations:
+Recommendations appear as separate annotations for each container and resource type:
 
 ```yaml
 apiVersion: apps/v1
@@ -34,23 +34,21 @@ kind: Deployment
 metadata:
   name: my-app
   annotations:
-    optipod.io/recommendation: |
-      {
-        "containers": {
-          "my-app": {
-            "requests": {"cpu": "250m", "memory": "512Mi"},
-            "limits": {"cpu": "500m", "memory": "1Gi"}
-          }
-        },
-        "confidence": "high",
-        "timestamp": "2026-01-24T10:30:00Z",
-        "estimatedImpact": {
-          "cpuSavings": "50%",
-          "memorySavings": "30%",
-          "riskLevel": "low"
-        }
-      }
-    optipod.io/last-updated: "2026-01-24T10:30:00Z"
+    # Management annotations
+    optipod.io/managed: "true"
+    optipod.io/policy: "production-policy"
+    optipod.io/last-recommendation: "2026-01-26T10:30:00Z"
+
+    # Resource recommendations for 'my-app' container
+    optipod.io/cpu-request.my-app: "250m"
+    optipod.io/memory-request.my-app: "512Mi"
+    optipod.io/cpu-limit.my-app: "500m"
+    optipod.io/memory-limit.my-app: "1Gi"
+
+    # Strategy annotation
+    optipod.io/strategy: "webhook"
+spec:
+  # ... deployment spec unchanged
 ```
 
 ### When to Use
@@ -59,6 +57,19 @@ metadata:
 - **GitOps workflows**: Review and commit changes through Git
 - **Strict change control**: Manual approval required for all changes
 - **Testing**: Validate recommendations before auto-applying
+- **Critical workloads**: Extra caution for production systems
+
+### Viewing Recommendations
+
+```bash
+# Get all OptiPod annotations
+kubectl get deployment my-app -o json | \
+  jq '.metadata.annotations | with_entries(select(.key | startswith("optipod.io/")))'
+
+# Get specific container recommendations
+echo "CPU Request: $(kubectl get deployment my-app -o jsonpath='{.metadata.annotations.optipod\.io/cpu-request\.my-app}')"
+echo "Memory Request: $(kubectl get deployment my-app -o jsonpath='{.metadata.annotations.optipod\.io/memory-request\.my-app}')"
+```
 
 ### Applying Recommendations
 
@@ -67,133 +78,244 @@ You have several options for applying recommendations:
 #### Option 1: Manual kubectl
 
 ```bash
-# Extract recommendation
-kubectl get deployment my-app -o jsonpath='{.metadata.annotations.optipod\.io/recommendation}'
-
-# Update deployment manually
+# Apply recommendations manually
 kubectl set resources deployment my-app \
   --requests=cpu=250m,memory=512Mi \
   --limits=cpu=500m,memory=1Gi
 ```
 
-#### Option 2: GitOps Workflow
+#### Option 2: GitOps Workflow (Recommended)
 
-1. Review recommendation annotation
-2. Update deployment YAML in Git
+1. Review recommendation annotations on workload
+2. Update deployment YAML in Git repository
 3. Commit and push changes
 4. GitOps tool (ArgoCD/Flux) applies changes
+
+**Example:**
+```yaml
+# Update your Git repository
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: my-app
+        resources:
+          requests:
+            cpu: 250m      # From optipod.io/cpu-request.my-app
+            memory: 512Mi  # From optipod.io/memory-request.my-app
+          limits:
+            cpu: 500m      # From optipod.io/cpu-limit.my-app
+            memory: 1Gi    # From optipod.io/memory-limit.my-app
+```
 
 #### Option 3: Automation Script
 
 ```bash
 #!/bin/bash
 # apply-recommendations.sh
-kubectl get deployments -l optipod.io/enabled=true -o json | \
-  jq -r '.items[] | select(.metadata.annotations."optipod.io/recommendation" != null) | .metadata.name' | \
-  while read deployment; do
-    echo "Applying recommendation for $deployment"
-    # Extract and apply recommendation
-  done
+
+DEPLOYMENT=$1
+NAMESPACE=${2:-default}
+
+if [ -z "$DEPLOYMENT" ]; then
+  echo "Usage: $0 <deployment-name> [namespace]"
+  exit 1
+fi
+
+# Get container names
+CONTAINERS=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o json | \
+  jq -r '.metadata.annotations | keys[] | select(startswith("optipod.io/cpu-request.")) | sub("optipod.io/cpu-request."; "")')
+
+for CONTAINER in $CONTAINERS; do
+  CPU_REQ=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o jsonpath="{.metadata.annotations.optipod\.io/cpu-request\.$CONTAINER}")
+  MEM_REQ=$(kubectl get deployment $DEPLOYMENT -n $NAMESPACE -o jsonpath="{.metadata.annotations.optipod\.io/memory-request\.$CONTAINER}")
+
+  echo "Applying recommendations for container: $CONTAINER"
+  echo "  CPU Request: $CPU_REQ"
+  echo "  Memory Request: $MEM_REQ"
+
+  kubectl set resources deployment $DEPLOYMENT -n $NAMESPACE \
+    --containers=$CONTAINER \
+    --requests=cpu=$CPU_REQ,memory=$MEM_REQ
+done
 ```
 
 ## Auto Mode
 
-OptiPod automatically applies recommendations with built-in safety guardrails.
+**Automatic application mode.** OptiPod generates recommendations and automatically applies them to workloads.
 
 ### How It Works
 
 1. OptiPod analyzes metrics and generates recommendations
-2. Validates recommendations against safety rules
-3. Automatically applies changes using the configured update strategy
-4. Monitors results and adjusts if needed
+2. Stores recommendations as annotations (same as Recommend mode)
+3. **Automatically applies recommendations** based on update strategy
+4. Monitors workload health after changes
 
-### Safety Guardrails
-
-Auto mode includes multiple safety mechanisms:
-
-- **Confidence threshold**: Only applies high-confidence recommendations
-- **Change limits**: Maximum 50% change per update (configurable)
-- **Rate limiting**: Minimum 24 hours between updates (configurable)
-- **Memory floor**: Never reduces memory below 64Mi (configurable)
-- **Rollback detection**: Monitors for OOM kills or crashes
-
-### Configuration
+### Enabling Auto Mode
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: auto-policy
+  namespace: production
 spec:
-  mode: Auto
-  updateStrategy: ServerSideApply
-  safetyConfig:
-    confidenceThreshold: high
-    maxChangePercent: 50
-    minUpdateInterval: 24h
-    memoryFloor: 64Mi
-    enableRollback: true
+  mode: Auto  # Enable automatic application
+
+  selector:
+    workloadSelector:
+      matchLabels:
+        optipod.io/enabled: "true"
+
+  metricsConfig:
+    provider: prometheus
+    rollingWindow: 7d
+    percentile: P90
+    safetyFactor: 1.2
+
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 64Mi
+      max: 8Gi
+
+  updateStrategy:
+    strategy: ssa  # or "webhook"
+    rolloutStrategy: onNextRestart
+    allowUnsafeMemoryDecrease: false
+    gradualDecreaseConfig:
+      enabled: true
+      memoryDecreasePercentage: 10
 ```
+
+### Update Strategies
+
+OptiPod supports two update strategies in Auto mode:
+
+#### Server-Side Apply (SSA)
+
+Updates workload specs directly using Kubernetes Server-Side Apply:
+
+```yaml
+updateStrategy:
+  strategy: ssa
+  useServerSideApply: true
+  updateRequestsOnly: true
+```
+
+**Pros:**
+- Direct updates to workload specs
+- Field-level ownership tracking
+- Works with all workload types
+
+**Cons:**
+- May conflict with GitOps controllers
+- Changes not reflected in Git
+
+#### Webhook Strategy
+
+Uses mutating webhook to inject resources at pod creation:
+
+```yaml
+updateStrategy:
+  strategy: webhook
+  rolloutStrategy: onNextRestart
+```
+
+**Pros:**
+- GitOps-safe (doesn't modify workload specs)
+- No conflicts with ArgoCD/Flux
+- Changes stored in annotations only
+
+**Cons:**
+- Requires webhook deployment
+- Only applies on pod restart
 
 ### When to Use
 
-- **Production workloads**: After validating in Recommend mode
-- **High confidence**: Stable workloads with predictable patterns
-- **Operational efficiency**: Reduce manual intervention
-- **Dynamic environments**: Workloads with changing resource needs
+- **Stable workloads**: Consistent usage patterns
+- **Non-critical environments**: Development, staging
+- **After validation**: Tested in Recommend mode first
+- **With monitoring**: Active observability in place
+- **Gradual rollout**: Start with a few workloads
+
+### Safety Considerations
+
+Auto mode includes safety features:
+
+1. **Resource bounds**: Min/max limits prevent extreme values
+2. **Safety factor**: Adds headroom above observed usage
+3. **Gradual decrease**: Large memory reductions applied incrementally
+4. **Memory safety**: Blocks unsafe memory decreases by default
+5. **Reconciliation interval**: Limits frequency of changes
 
 ### Monitoring Auto Mode
 
-Track OptiPod's automatic changes:
-
 ```bash
-# View policy status
-kubectl get optimizationpolicy auto-policy -o yaml
+# Check policy status
+kubectl describe optimizationpolicy auto-policy
 
-# Check recent updates
-kubectl get events --field-selector involvedObject.kind=OptimizationPolicy
+# Check workload annotations
+kubectl get deployment my-app -o yaml | grep optipod.io
 
-# Monitor workload changes
-kubectl get deployment my-app -o yaml | grep optipod.io/last-applied
+# Check last applied time
+kubectl get deployment my-app \
+  -o jsonpath='{.metadata.annotations.optipod\.io/last-applied}'
+
+# Monitor resource usage
+kubectl top pod -l app=my-app
 ```
 
 ## Disabled Mode
 
-Temporarily stops OptiPod from analyzing or updating workloads.
+**Paused mode.** OptiPod stops processing workloads under this policy.
 
 ### How It Works
 
-1. OptiPod stops generating new recommendations
-2. Existing recommendations remain but aren't updated
-3. No changes are applied to workloads
-4. Policy remains in the cluster
+1. OptiPod stops analyzing workloads matching this policy
+2. No new recommendations are generated
+3. Existing annotations remain unchanged
+4. No automatic updates are applied
 
-### When to Use
-
-- **Troubleshooting**: Isolate issues
-- **Maintenance windows**: Prevent changes during critical periods
-- **Testing**: Temporarily pause optimization
-- **Incident response**: Stop automated changes during incidents
-
-### Configuration
+### Enabling Disabled Mode
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: my-policy
 spec:
-  mode: Disabled
-  # Other settings remain but are not active
+  mode: Disabled  # Pause optimization
+  # ... rest of spec
 ```
+
+### When to Use
+
+- **Troubleshooting**: Isolate OptiPod from issues
+- **Maintenance**: During cluster maintenance windows
+- **Investigation**: When recommendations seem incorrect
+- **Temporary pause**: Stop optimization without deleting policy
+- **Emergency**: Quick way to disable OptiPod
+
+### Behavior
+
+- Existing recommendations remain as annotations
+- No new recommendations generated
+- No automatic updates applied
+- Policy still exists and can be re-enabled
 
 ### Re-enabling
 
-Simply change the mode back to Recommend or Auto:
+Simply change the mode back:
 
 ```bash
-kubectl patch optimizationpolicy my-policy \
-  --type merge \
+kubectl patch optimizationpolicy my-policy --type merge \
   -p '{"spec":{"mode":"Recommend"}}'
 ```
 
@@ -201,78 +323,123 @@ kubectl patch optimizationpolicy my-policy \
 
 ### Recommend → Auto
 
-Recommended progression after building confidence:
+**Recommended progression:**
 
-1. Run in Recommend mode for 2-4 weeks
-2. Review recommendations and verify accuracy
-3. Apply recommendations manually and monitor results
-4. Switch to Auto mode with conservative safety settings
-5. Gradually relax safety settings as confidence grows
+1. Start in Recommend mode
+2. Review recommendations for 1-2 weeks
+3. Validate recommendations are reasonable
+4. Test on non-critical workloads first
+5. Switch to Auto mode gradually
 
 ```bash
-kubectl patch optimizationpolicy my-policy \
-  --type merge \
+# Switch to Auto mode
+kubectl patch optimizationpolicy my-policy --type merge \
   -p '{"spec":{"mode":"Auto"}}'
 ```
 
 ### Auto → Recommend
 
-Revert to manual control if needed:
+**Rollback to manual control:**
 
 ```bash
-kubectl patch optimizationpolicy my-policy \
-  --type merge \
+# Switch back to Recommend mode
+kubectl patch optimizationpolicy my-policy --type merge \
   -p '{"spec":{"mode":"Recommend"}}'
 ```
 
+Existing recommendations remain, but no new automatic updates.
+
 ### Any Mode → Disabled
 
-Temporarily pause optimization:
+**Emergency stop:**
 
 ```bash
-kubectl patch optimizationpolicy my-policy \
-  --type merge \
+# Disable policy
+kubectl patch optimizationpolicy my-policy --type merge \
   -p '{"spec":{"mode":"Disabled"}}'
 ```
 
+## Mode Comparison
+
+### Recommend Mode
+
+**Pros:**
+- ✅ Safest option
+- ✅ Full control over changes
+- ✅ GitOps-friendly
+- ✅ Easy to review before applying
+
+**Cons:**
+- ❌ Manual work required
+- ❌ Slower optimization
+- ❌ Can forget to apply recommendations
+
+### Auto Mode
+
+**Pros:**
+- ✅ Automatic optimization
+- ✅ Continuous adaptation
+- ✅ Reduced manual work
+- ✅ Faster optimization
+
+**Cons:**
+- ❌ Less control
+- ❌ Requires trust in OptiPod
+- ❌ May conflict with GitOps (SSA strategy)
+- ❌ Needs monitoring
+
+### Disabled Mode
+
+**Pros:**
+- ✅ Quick pause
+- ✅ Preserves policy configuration
+- ✅ Easy to re-enable
+
+**Cons:**
+- ❌ No optimization
+- ❌ Workloads may become over/under-provisioned
+
 ## Best Practices
 
-### Start Conservative
+1. **Start with Recommend**: Always begin in Recommend mode
+2. **Test thoroughly**: Validate recommendations before Auto mode
+3. **Gradual rollout**: Enable Auto mode for a few workloads first
+4. **Monitor closely**: Watch for issues after enabling Auto mode
+5. **Use appropriate strategy**: Webhook for GitOps, SSA otherwise
+6. **Set safety bounds**: Configure appropriate resource bounds
+7. **Enable gradual decrease**: Safer memory optimization
+8. **Have rollback plan**: Know how to quickly disable if needed
 
-1. Begin with Recommend mode
-2. Use long lookback windows (14+ days)
-3. Set strict resource bounds
-4. Review recommendations thoroughly
+## Troubleshooting
 
-### Build Confidence
+### No Recommendations in Recommend Mode
 
-1. Apply recommendations to non-critical workloads first
-2. Monitor results for 1-2 weeks
-3. Gradually expand to more workloads
-4. Document any issues or adjustments needed
+Check:
+- Workload has correct labels matching policy selector
+- Sufficient metrics data available (check rolling window)
+- Policy is not in Disabled mode
+- Metrics provider is accessible
 
-### Production Rollout
+### Auto Mode Not Applying Changes
 
-1. Switch to Auto mode for non-critical workloads
-2. Use conservative safety settings
-3. Monitor closely for 2-4 weeks
-4. Expand to critical workloads
-5. Fine-tune safety settings based on experience
+Verify:
+- Mode is set to `Auto`
+- Update strategy is configured
+- Webhook is deployed (if using webhook strategy)
+- No safety checks blocking updates
+- Check policy status for errors
 
-### Emergency Procedures
+### Unexpected Changes in Auto Mode
 
-If OptiPod causes issues:
-
-1. Switch to Disabled mode immediately
-2. Investigate the problem
-3. Adjust policy settings
-4. Test in Recommend mode
-5. Re-enable Auto mode when confident
+Review:
+- Policy configuration (bounds, safety factor)
+- Recent metrics data
+- Safety settings (allowUnsafeMemoryDecrease)
+- Gradual decrease configuration
 
 ## Next Steps
 
-Learn about how OptiPod applies changes:
-
-- [Update Strategies](/docs/concepts/update-strategies)
-- [Safety Model](/docs/concepts/safety-model)
-- [Creating Policies](/docs/guides/creating-policies)
+- [Understand update strategies](/docs/concepts/update-strategies)
+- [Learn about safety model](/docs/concepts/safety-model)
+- [Switch to Auto mode safely](/docs/guides/switching-to-auto)
+- [Create your first policy](/docs/guides/creating-policies)

--- a/website/src/content/docs/docs/concepts/terminology.mdx
+++ b/website/src/content/docs/docs/concepts/terminology.mdx
@@ -21,23 +21,38 @@ A Kubernetes operator is a software extension that uses custom resources to mana
 
 A Custom Resource Definition (CRD) that defines how OptiPod should optimize workloads. Each policy specifies:
 
-- **Target workloads**: Which resources to optimize (by kind, namespace, labels)
+- **Target workloads**: Which resources to optimize (by namespace, labels, workload types)
 - **Operational mode**: Recommend, Auto, or Disabled
-- **Metrics configuration**: Data source and lookback window
+- **Metrics configuration**: Provider, rolling window, percentile, safety factor
 - **Resource bounds**: Min/max limits for CPU and memory
-- **Update strategy**: How to apply recommendations
+- **Update strategy**: How to apply recommendations (SSA or webhook)
 
 **Example:**
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: production-policy
-  namespace: production
 spec:
   mode: Recommend
-  targetWorkloads:
-    kinds: [Deployment, StatefulSet]
+  selector:
+    workloadSelector:
+      matchLabels:
+        env: production
+    workloadTypes:
+      include: [Deployment, StatefulSet]
+  metricsConfig:
+    provider: prometheus
+    rollingWindow: 7d
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 2000m
+    memory:
+      min: 64Mi
+      max: 4Gi
+  updateStrategy:
+    strategy: webhook
 ```
 
 ### Workload
@@ -47,21 +62,23 @@ A Kubernetes resource that runs containers. OptiPod supports:
 - **Deployments**: Stateless applications
 - **StatefulSets**: Stateful applications
 - **DaemonSets**: Node-level services
-- **Jobs**: Batch workloads
-- **CronJobs**: Scheduled tasks
 
-Workloads must be labeled to opt-in to optimization.
+Note: Jobs and CronJobs are not currently supported.
 
 ### Recommendation
 
-A suggested change to a workload's resource requests and limits, based on actual usage patterns. Recommendations include:
+A suggested change to a workload's resource requests and limits, based on actual usage patterns. Recommendations are calculated using:
 
-- **Resource values**: Suggested CPU and memory requests/limits
-- **Confidence level**: High, medium, or low
-- **Impact estimation**: Expected savings or improvements
-- **Reasoning**: Why the recommendation was made
+- **Percentile-based analysis**: P50, P90, or P99 of historical usage
+- **Safety factor**: Multiplier applied to percentile (default 1.2)
+- **Resource bounds**: Min/max constraints from policy
+- **Weight**: Policy priority when multiple policies match
 
-Recommendations are stored as annotations on the workload.
+Recommendations are stored as per-resource annotations on the workload:
+- `optipod.io/cpu-request.<container-name>`
+- `optipod.io/memory-request.<container-name>`
+- `optipod.io/cpu-limit.<container-name>`
+- `optipod.io/memory-limit.<container-name>`
 
 ## GitOps
 
@@ -70,20 +87,28 @@ Recommendations are stored as annotations on the workload.
 A deployment methodology where Git is the single source of truth for infrastructure and application configuration. Changes are made through Git commits and automatically applied to the cluster.
 
 **OptiPod's GitOps compatibility:**
-- Recommend mode stores suggestions as annotations
-- You review and commit changes to Git
-- Your GitOps tool (ArgoCD, Flux) applies changes
-- No webhook conflicts or unexpected modifications
+
+**With Webhook Strategy:**
+- Recommend mode stores suggestions as annotations only
+- Workload specs in Git remain unchanged
+- You review and commit changes to Git if desired
+- Webhook applies recommendations at pod creation time
+- No conflicts with ArgoCD/Flux
+
+**With SSA Strategy:**
+- OptiPod directly updates resource fields in workload specs
+- May require configuring GitOps tools to ignore resource fields
+- Use ArgoCD's `ignoreDifferences` or SSA sync options
 
 ### Server-Side Apply (SSA)
 
-A Kubernetes feature that allows multiple controllers to manage different fields of the same resource without conflicts. OptiPod can use SSA to apply recommendations while respecting GitOps ownership.
+A Kubernetes feature that allows multiple controllers to manage different fields of the same resource without conflicts. OptiPod can use SSA to apply recommendations directly to workload specs.
 
 **Benefits:**
 - No webhook required
-- Works with GitOps tools
+- Direct field updates
 - Clear field ownership
-- Conflict-free updates
+- In-place pod resize support (Kubernetes 1.27+)
 
 ## Metrics
 
@@ -91,26 +116,53 @@ A Kubernetes feature that allows multiple controllers to manage different fields
 
 The source of resource usage data. OptiPod supports:
 
-- **Prometheus**: Full-featured metrics with historical data
-- **metrics-server**: Basic CPU/memory metrics
-- **Custom providers**: Integrate your own metrics source
+- **Prometheus**: Full-featured metrics with historical data (recommended)
+- **metrics-server**: Basic CPU/memory metrics with sampling
+- **Custom providers**: Integrate your own metrics source (future)
 
-### Lookback Window
+### Rolling Window
 
 The time period OptiPod analyzes to generate recommendations. Longer windows provide more stable recommendations but take longer to react to changes.
 
 **Typical values:**
 - **7 days**: Balanced (default)
 - **14 days**: More stable, slower to adapt
-- **3 days**: Faster adaptation, less stable
+- **24 hours**: Faster adaptation, less stable
+
+**Configuration:**
+```yaml
+metricsConfig:
+  rollingWindow: 7d  # or 24h, 14d, 30d
+```
 
 ### Percentile
 
-The statistical measure used to determine resource recommendations. OptiPod typically uses P95 (95th percentile) to ensure recommendations handle peak usage.
+The statistical measure used to determine resource recommendations. OptiPod supports P50, P90, and P99.
 
 **Example:**
-- P95 CPU = 250m means 95% of the time, CPU usage is below 250m
-- Recommendations include headroom above P95 for safety
+- P90 CPU = 250m means 90% of the time, CPU usage is below 250m
+- P99 provides more headroom for spikes
+- P50 is more aggressive but riskier
+
+**Configuration:**
+```yaml
+metricsConfig:
+  percentile: P90  # or P50, P99
+```
+
+### Safety Factor
+
+A multiplier applied to the selected percentile to add headroom. Default is 1.2 (20% above percentile).
+
+**Example:**
+- P90 = 250m, safety factor = 1.2
+- Recommendation = 250m × 1.2 = 300m
+
+**Configuration:**
+```yaml
+metricsConfig:
+  safetyFactor: 1.2  # 1.0 = no headroom, 1.5 = 50% headroom
+```
 
 ## Resource Management
 
@@ -119,8 +171,8 @@ The statistical measure used to determine resource recommendations. OptiPod typi
 The amount of CPU/memory Kubernetes guarantees for a container. Used for scheduling decisions.
 
 **Impact:**
-- Too low: Pod may be scheduled on overloaded nodes
-- Too high: Wastes cluster capacity
+- Too low: Pod may be scheduled on overloaded nodes, leading to throttling or OOM
+- Too high: Wastes cluster capacity and increases costs
 
 ### Resource Limit
 
@@ -130,46 +182,86 @@ The maximum amount of CPU/memory a container can use.
 - CPU: Container is throttled if exceeded
 - Memory: Container is OOM-killed if exceeded
 
+### Limit Configuration
+
+OptiPod can calculate limits based on requests using multipliers:
+
+```yaml
+updateStrategy:
+  limitConfig:
+    cpuLimitMultiplier: 1.0      # limit = request × 1.0
+    memoryLimitMultiplier: 1.1   # limit = request × 1.1
+```
+
+Or you can update only requests and leave limits unchanged:
+
+```yaml
+updateStrategy:
+  updateRequestsOnly: true
+```
+
 ### Vertical Pod Autoscaler (VPA)
 
 Kubernetes' built-in solution for adjusting resource requests/limits. OptiPod is an alternative designed to be more GitOps-friendly and explainable.
 
 **Key differences:**
-- VPA uses webhooks (can conflict with GitOps)
-- OptiPod offers Recommend mode and SSA
-- OptiPod provides impact estimation
+- VPA uses webhooks that can conflict with GitOps
+- OptiPod offers webhook strategy that's GitOps-safe
+- OptiPod provides explainable recommendations with percentile-based calculations
+- OptiPod supports gradual memory decreases for safety
 
 ## Safety
 
-### Confidence Level
+### Memory Safety
 
-OptiPod's assessment of how reliable a recommendation is, based on:
+OptiPod includes built-in protections to prevent dangerous memory reductions:
 
-- Amount of historical data
-- Stability of usage patterns
-- Variance in metrics
+**Default behavior:**
+- Memory increases are always allowed
+- Memory decreases are blocked if they could cause OOM kills
+- Checks current memory usage before reducing
 
-**Levels:**
-- **High**: Stable patterns, sufficient data
-- **Medium**: Some variance or limited data
-- **Low**: Unstable patterns or insufficient data
+**Override (use with caution):**
+```yaml
+updateStrategy:
+  allowUnsafeMemoryDecrease: true
+```
 
-### Safety Guardrails
+### Gradual Memory Decrease
 
-Built-in protections that prevent dangerous recommendations:
+For safer memory optimization, OptiPod can apply large decreases incrementally:
 
-- **Memory floor**: Never reduce memory below safe thresholds
-- **Change limits**: Maximum percentage change per update
-- **Rate limiting**: Minimum time between updates
-- **Confidence threshold**: Only apply high-confidence recommendations
+```yaml
+updateStrategy:
+  gradualDecreaseConfig:
+    enabled: true
+    memoryDecreasePercentage: 10      # Max 10% per reconciliation
+    minimumDecreaseThreshold: 100Mi   # Apply gradually if decrease > 100Mi
+    maximumTotalDecrease: 70          # Never decrease more than 70% total
+```
 
-### Impact Estimation
+### Resource Bounds
 
-OptiPod's prediction of how a recommendation will affect your workload:
+Min/max constraints that limit recommendations:
 
-- **Resource savings**: Expected reduction in requests
-- **Performance impact**: Potential effects on latency/throughput
-- **Risk level**: Assessment of change safety
+```yaml
+resourceBounds:
+  cpu:
+    min: 10m      # Never recommend less than 10m
+    max: 4000m    # Never recommend more than 4000m
+  memory:
+    min: 64Mi     # Never recommend less than 64Mi
+    max: 8Gi      # Never recommend more than 8Gi
+```
+
+### Policy Weight
+
+When multiple policies match the same workload, the policy with the highest weight takes precedence:
+
+```yaml
+spec:
+  weight: 200  # Higher weight = higher priority (default: 100)
+```
 
 ## Next Steps
 

--- a/website/src/content/docs/docs/concepts/update-strategies.mdx
+++ b/website/src/content/docs/docs/concepts/update-strategies.mdx
@@ -3,229 +3,312 @@ title: Update Strategies
 description: How OptiPod applies resource recommendations to workloads
 ---
 
-OptiPod supports two strategies for applying resource recommendations: **Webhook-based** and **Server-Side Apply (SSA)**. Each has different characteristics and use cases.
+OptiPod supports two strategies for applying resource recommendations: **Server-Side Apply (SSA)** and **Webhook-based**. Each has different characteristics and use cases.
 
 ## Strategy Comparison
 
-| Feature | Webhook | Server-Side Apply |
-|---------|---------|-------------------|
-| GitOps-safe | ⚠️ Can conflict | ✅ Yes |
-| Requires webhook | ✅ Yes | ❌ No |
-| Field ownership | Opaque | ✅ Clear |
-| Complexity | Higher | Lower |
-| Kubernetes version | 1.19+ | 1.22+ |
+| Feature | SSA | Webhook |
+|---------|-----|---------|
+| GitOps-safe | ✅ Yes | ✅ Yes (with proper config) |
+| Requires webhook | ❌ No | ✅ Yes |
+| Field ownership | ✅ Clear | Annotation-based |
+| Complexity | Lower | Higher |
+| Kubernetes version | 1.22+ | 1.19+ |
 
-## Server-Side Apply (Recommended)
+## Server-Side Apply (SSA)
 
-Server-Side Apply is the recommended strategy for most use cases. It uses Kubernetes' built-in field management to apply changes without conflicts.
+Server-Side Apply is the default strategy. It uses Kubernetes' built-in field management to apply changes directly to workload specs.
 
 ### How It Works
 
 1. OptiPod generates a recommendation
-2. Uses SSA to update only the resource fields it manages
-3. Other controllers (GitOps, HPA) can manage other fields
-4. Kubernetes tracks field ownership automatically
+2. Uses SSA to update resource fields in the workload spec
+3. Kubernetes tracks field ownership automatically
+4. Changes take effect on next pod restart (or immediately with in-place resize)
 
 ### Configuration
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: ssa-policy
 spec:
   mode: Auto
-  updateStrategy: ServerSideApply
-  ssaConfig:
-    fieldManager: optipod
-    force: false
+  selector:
+    workloadSelector:
+      matchLabels:
+        app: my-app
+  metricsConfig:
+    provider: prometheus
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 2000m
+    memory:
+      min: 64Mi
+      max: 4Gi
+  updateStrategy:
+    strategy: ssa
+    useServerSideApply: true
+    allowInPlaceResize: true
+    allowRecreate: false
 ```
 
 ### Advantages
 
-- **GitOps-friendly**: Works alongside ArgoCD, Flux, etc.
 - **No webhook**: Simpler deployment and fewer failure points
 - **Clear ownership**: Kubernetes tracks who manages each field
-- **Conflict resolution**: Automatic handling of competing updates
-
-### GitOps Integration
-
-SSA allows OptiPod and GitOps tools to coexist:
-
-```yaml
-# Git repository (managed by GitOps)
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-app
-spec:
-  replicas: 3  # Managed by GitOps
-  template:
-    spec:
-      containers:
-      - name: my-app
-        image: my-app:v1.0  # Managed by GitOps
-        resources:
-          requests:
-            cpu: 100m  # Managed by OptiPod
-            memory: 256Mi  # Managed by OptiPod
-```
-
-OptiPod updates resources, GitOps manages replicas and image. No conflicts!
+- **Direct updates**: Changes applied directly to workload specs
+- **In-place resize**: Can update resources without pod restarts (if supported)
 
 ### When to Use
 
-- **GitOps environments**: ArgoCD, Flux, or similar tools
-- **Multi-controller setups**: HPA, VPA, or other operators
-- **Production workloads**: Safer and more predictable
+- **Most environments**: SSA is the default and recommended strategy
 - **Kubernetes 1.22+**: SSA is stable and well-supported
+- **Direct control**: When you want OptiPod to directly manage resource fields
+- **In-place updates**: When you want to leverage in-place pod resize
 
 ## Webhook Strategy
 
-The webhook strategy intercepts pod creation requests and modifies resource specifications on-the-fly.
+The webhook strategy stores recommendations as annotations on workloads and uses a mutating webhook to inject them at pod creation time.
 
 ### How It Works
 
-1. OptiPod deploys a mutating webhook
-2. When a pod is created, Kubernetes calls the webhook
-3. Webhook injects recommended resource values
-4. Pod is created with updated resources
+1. OptiPod generates recommendations and stores them as annotations on the workload
+2. When a pod is created, Kubernetes calls the OptiPod webhook
+3. Webhook reads annotations from the parent workload
+4. Webhook injects recommended resource values into the pod spec
+5. Pod is created with updated resources
 
 ### Configuration
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: webhook-policy
 spec:
   mode: Auto
-  updateStrategy: Webhook
-  webhookConfig:
-    failurePolicy: Ignore
-    timeoutSeconds: 10
+  selector:
+    workloadSelector:
+      matchLabels:
+        app: my-app
+  metricsConfig:
+    provider: prometheus
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 2000m
+    memory:
+      min: 64Mi
+      max: 4Gi
+  updateStrategy:
+    strategy: webhook
+    rolloutStrategy: onNextRestart  # or immediate
 ```
+
+### Rollout Strategies
+
+The webhook strategy supports two rollout options:
+
+**onNextRestart** (default):
+- Annotations are updated on the workload
+- Changes apply when pods naturally restart
+- No forced restarts
+- GitOps-safe: workload spec unchanged
+
+**immediate**:
+- Annotations are updated on the workload
+- Triggers a rolling restart to apply changes immediately
+- Faster optimization
+- Still GitOps-safe: only annotations change
 
 ### Advantages
 
-- **Immediate effect**: Changes apply on next pod creation
-- **Works with older Kubernetes**: Supports 1.19+
-- **Familiar pattern**: Similar to VPA's approach
-
-### Disadvantages
-
-- **GitOps conflicts**: Can fight with GitOps tools
-- **Webhook complexity**: Additional component to manage
-- **Failure modes**: Webhook downtime affects pod creation
-- **Drift detection**: GitOps tools may see unexpected changes
+- **GitOps-friendly**: Workload specs remain unchanged
+- **Flexible rollout**: Control when changes take effect
+- **ArgoCD compatible**: No conflicts with GitOps tools
+- **Gradual adoption**: Easy to enable/disable per workload
 
 ### When to Use
 
-- **Non-GitOps environments**: Direct kubectl/API usage
-- **Older Kubernetes**: Versions before 1.22
-- **VPA migration**: Familiar pattern for VPA users
-- **Immediate updates**: Need changes on next pod restart
+- **GitOps environments**: ArgoCD, Flux, or similar tools
+- **Controlled rollouts**: When you want to control when changes apply
+- **Older Kubernetes**: Supports 1.19+
+- **Annotation-based workflow**: When you prefer metadata-driven updates
 
 ## Choosing a Strategy
 
-### Use Server-Side Apply if:
+### Use Server-Side Apply (SSA) if:
 
-- ✅ You use GitOps (ArgoCD, Flux, etc.)
+- ✅ You want direct control over resource fields
 - ✅ You run Kubernetes 1.22 or later
 - ✅ You want simpler deployment (no webhook)
-- ✅ You have multiple controllers managing workloads
-- ✅ You prefer explicit field ownership
+- ✅ You want to leverage in-place pod resize
+- ✅ You prefer immediate updates to workload specs
 
 ### Use Webhook if:
 
-- ✅ You don't use GitOps
+- ✅ You use GitOps (ArgoCD, Flux, etc.)
+- ✅ You want workload specs to remain unchanged
+- ✅ You need to control when changes take effect
+- ✅ You want annotation-based recommendations
 - ✅ You need to support Kubernetes 1.19-1.21
-- ✅ You're migrating from VPA
-- ✅ You want immediate updates on pod restart
+
+## GitOps Integration
+
+Both strategies work with GitOps, but in different ways:
+
+### SSA with GitOps
+
+OptiPod directly updates resource fields in workload specs. To avoid conflicts:
+
+1. Configure ArgoCD/Flux to ignore resource fields:
+
+```yaml
+# ArgoCD Application
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /spec/template/spec/containers/0/resources
+```
+
+2. Or use SSA in ArgoCD (v2.5+):
+
+```yaml
+syncPolicy:
+  syncOptions:
+  - ServerSideApply=true
+```
+
+### Webhook with GitOps
+
+OptiPod stores recommendations as annotations only. Workload specs remain unchanged:
+
+```yaml
+# In Git (managed by GitOps)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        resources:
+          requests:
+            cpu: 100m  # Original value from Git
+            memory: 256Mi
+
+---
+# OptiPod adds annotations (not in Git)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  annotations:
+    optipod.io/cpu-request.app: "250m"
+    optipod.io/memory-request.app: "512Mi"
+```
+
+The webhook reads annotations and injects values at pod creation. No Git conflicts!
 
 ## Migration Between Strategies
+
+### SSA → Webhook
+
+1. Deploy webhook component:
+```bash
+helm upgrade optipod optipod/optipod --set webhook.enabled=true
+```
+
+2. Update policy to use webhook:
+```yaml
+spec:
+  updateStrategy:
+    strategy: webhook
+    rolloutStrategy: onNextRestart
+```
+
+3. Recommendations will be stored as annotations on next reconciliation
 
 ### Webhook → SSA
 
 1. Update policy to use SSA:
 ```yaml
 spec:
-  updateStrategy: ServerSideApply
+  updateStrategy:
+    strategy: ssa
+    useServerSideApply: true
 ```
 
-2. Remove webhook configuration:
+2. OptiPod will apply recommendations directly to workload specs
+
+3. Optionally disable webhook if no longer needed:
 ```bash
-kubectl delete mutatingwebhookconfiguration optipod-webhook
+helm upgrade optipod optipod/optipod --set webhook.enabled=false
 ```
-
-3. Restart workloads to apply SSA-managed resources
-
-### SSA → Webhook
-
-1. Deploy webhook:
-```bash
-kubectl apply -f webhook-config.yaml
-```
-
-2. Update policy:
-```yaml
-spec:
-  updateStrategy: Webhook
-```
-
-3. Restart workloads to trigger webhook
 
 ## Advanced Configuration
 
 ### Server-Side Apply Options
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: advanced-ssa
 spec:
-  updateStrategy: ServerSideApply
-  ssaConfig:
-    # Field manager name (appears in field ownership)
-    fieldManager: optipod
+  updateStrategy:
+    strategy: ssa
 
-    # Force field ownership (use with caution)
-    force: false
+    # Use Server-Side Apply for field-level ownership
+    useServerSideApply: true
 
-    # Fields to manage
-    managedFields:
-      - resources.requests.cpu
-      - resources.requests.memory
-      - resources.limits.cpu
-      - resources.limits.memory
+    # Enable in-place pod resize (requires Kubernetes 1.27+)
+    allowInPlaceResize: true
+
+    # Allow pod recreation if in-place resize not available
+    allowRecreate: false
+
+    # Update only requests, leave limits unchanged
+    updateRequestsOnly: true
+
+    # Configure limit calculation
+    limitConfig:
+      cpuLimitMultiplier: 1.0
+      memoryLimitMultiplier: 1.1
 ```
 
 ### Webhook Options
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: advanced-webhook
 spec:
-  updateStrategy: Webhook
-  webhookConfig:
-    # What to do if webhook fails
-    failurePolicy: Ignore  # or Fail
+  updateStrategy:
+    strategy: webhook
 
-    # Webhook timeout
-    timeoutSeconds: 10
+    # When to apply changes
+    rolloutStrategy: onNextRestart  # or immediate
 
-    # Namespace selector
-    namespaceSelector:
-      matchLabels:
-        optipod.io/webhook: enabled
+    # Update only requests, leave limits unchanged
+    updateRequestsOnly: true
 
-    # Object selector
-    objectSelector:
-      matchLabels:
-        optipod.io/enabled: "true"
+    # Configure limit calculation
+    limitConfig:
+      cpuLimitMultiplier: 1.0
+      memoryLimitMultiplier: 1.1
 ```
 
 ## Troubleshooting
@@ -235,52 +318,71 @@ spec:
 **Problem**: Changes not applying
 
 ```bash
-# Check field ownership
-kubectl get deployment my-app -o yaml | grep -A 20 managedFields
+# Check policy status
+kubectl get optimizationpolicy my-policy -o yaml
 
-# Verify OptiPod has ownership
-kubectl get deployment my-app -o json | \
-  jq '.metadata.managedFields[] | select(.manager=="optipod")'
+# Check workload for OptiPod annotations
+kubectl get deployment my-app -o yaml | grep optipod.io
+
+# Check controller logs
+kubectl logs -n optipod-system -l app=optipod-controller
 ```
 
-**Solution**: Use `force: true` to take ownership (carefully!)
+**Solution**: Verify policy selector matches workload labels
 
 ### Webhook Issues
 
-**Problem**: Pods not starting
+**Problem**: Pods not getting recommendations
 
 ```bash
-# Check webhook status
+# Check webhook is running
+kubectl get pods -n optipod-system -l app=optipod-webhook
+
+# Check webhook configuration
 kubectl get mutatingwebhookconfiguration optipod-webhook
 
 # Check webhook logs
 kubectl logs -n optipod-system -l app=optipod-webhook
 ```
 
-**Solution**: Set `failurePolicy: Ignore` to allow pods to start if webhook fails
+**Solution**: Ensure webhook is deployed and cert-manager is working
+
+**Problem**: Webhook blocking pod creation
+
+```bash
+# Check webhook events
+kubectl get events -A | grep webhook
+
+# Temporarily disable webhook
+kubectl delete mutatingwebhookconfiguration optipod-webhook
+```
+
+**Solution**: Fix webhook issues or use SSA strategy instead
 
 ## Best Practices
 
 ### For SSA
 
-1. Use descriptive field manager names
-2. Don't use `force: true` unless necessary
-3. Document which fields OptiPod manages
-4. Coordinate with GitOps team on field ownership
+1. Use `allowInPlaceResize: true` on Kubernetes 1.27+
+2. Set `allowRecreate: false` for production workloads
+3. Consider `updateRequestsOnly: true` to preserve manual limit settings
+4. Monitor for pod restarts after updates
 
 ### For Webhook
 
-1. Set appropriate timeout values
-2. Use `failurePolicy: Ignore` for non-critical workloads
-3. Monitor webhook availability
-4. Have fallback plan if webhook fails
+1. Use `rolloutStrategy: onNextRestart` for safer updates
+2. Use `rolloutStrategy: immediate` only for non-critical workloads
+3. Ensure webhook is highly available
+4. Monitor webhook latency and errors
+5. Have fallback plan if webhook fails
 
 ### General
 
 1. Test strategy changes in non-production first
 2. Document your chosen strategy
-3. Monitor for conflicts or issues
+3. Monitor for issues after strategy changes
 4. Have rollback plan ready
+5. Consider your GitOps workflow when choosing
 
 ## Next Steps
 
@@ -288,4 +390,4 @@ Learn about OptiPod's safety mechanisms:
 
 - [Safety Model](/docs/concepts/safety-model)
 - [Creating Policies](/docs/guides/creating-policies)
-- [Troubleshooting](/docs/advanced/troubleshooting)
+- [Switching to Auto Mode](/docs/guides/switching-to-auto)

--- a/website/src/content/docs/docs/guides/switching-to-auto.mdx
+++ b/website/src/content/docs/docs/guides/switching-to-auto.mdx
@@ -3,16 +3,16 @@ title: Switching to Auto Mode
 description: How to safely transition from Recommend to Auto mode
 ---
 
-Auto mode allows OptiPod to automatically apply resource recommendations with safety guardrails. This guide walks you through the transition from manual Recommend mode to automated Auto mode.
+Auto mode allows OptiPod to automatically apply resource recommendations. This guide walks you through the transition from manual Recommend mode to automated Auto mode.
 
 ## Prerequisites
 
 Before switching to Auto mode, ensure:
 
 - ✅ OptiPod has been running in Recommend mode for 2+ weeks
-- ✅ You've reviewed and manually applied several recommendations
-- ✅ Manual applications have been successful
-- ✅ You understand the safety model
+- ✅ You've reviewed recommendations on several workloads
+- ✅ Recommendations appear reasonable and stable
+- ✅ You understand the update strategy (SSA vs webhook)
 - ✅ Monitoring is in place to detect issues
 
 ## Readiness Checklist
@@ -22,20 +22,20 @@ Before switching to Auto mode, ensure:
 Check that recommendations have been accurate:
 
 ```bash
-# Review all recommendations
-kubectl get deployments -l optipod.io/enabled=true -A \
-  -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.metadata.annotations.optipod\.io/recommendation}{"\n"}{end}' | \
-  jq -r '. | select(. != null)'
+# Review recommendations on deployments
+kubectl get deployments -A -o json | \
+  jq -r '.items[] | select(.metadata.annotations."optipod.io/managed" == "true") |
+    "\(.metadata.namespace)/\(.metadata.name): CPU=\(.metadata.annotations."optipod.io/cpu-request.app" // "none") Memory=\(.metadata.annotations."optipod.io/memory-request.app" // "none")"'
 ```
 
 **Questions to ask:**
 - Have recommendations been consistently reasonable?
-- Did manually applied recommendations work well?
-- Are confidence levels mostly "high"?
+- Are they stable over time?
+- Do they align with actual usage patterns?
 
-### 2. Verify Safety Configuration
+### 2. Verify Policy Configuration
 
-Ensure your policy has appropriate safety settings:
+Ensure your policy has appropriate settings:
 
 ```bash
 kubectl get optimizationpolicy <policy-name> -o yaml
@@ -43,22 +43,32 @@ kubectl get optimizationpolicy <policy-name> -o yaml
 
 Look for:
 ```yaml
-safetyConfig:
-  confidenceThreshold: high
-  maxChangePercent: 50
-  minUpdateInterval: 24h
-  memoryFloor: 64Mi
-  memoryHeadroom: 20%
-  enableRollback: true
+spec:
+  mode: Recommend  # Will change to Auto
+  metricsConfig:
+    rollingWindow: 7d
+    percentile: P90
+    safetyFactor: 1.2
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 2000m
+    memory:
+      min: 64Mi
+      max: 4Gi
+  updateStrategy:
+    strategy: webhook  # or ssa
+    rolloutStrategy: onNextRestart
+    updateRequestsOnly: true
 ```
 
 ### 3. Check Monitoring
 
 Verify you can monitor:
-- Pod status and restarts
-- Resource usage (kubectl top)
+- Pod status and restarts: `kubectl get pods -w`
+- Resource usage: `kubectl top pods`
 - Application metrics (latency, errors)
-- OOM kills and crashes
+- OOM kills: `kubectl get events --field-selector reason=OOMKilled`
 
 ### 4. Prepare Rollback Plan
 
@@ -83,25 +93,23 @@ Start with one low-risk workload.
 #### Step 1: Create Test Policy
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: auto-test-policy
-  namespace: development
 spec:
   mode: Auto
-  updateStrategy: ServerSideApply
 
-  targetWorkloads:
-    kinds:
-      - Deployment
-    labelSelector:
+  selector:
+    workloadSelector:
       matchLabels:
         optipod.io/auto-test: "true"  # Specific label for testing
 
   metricsConfig:
     provider: prometheus
-    lookbackWindow: 7d
+    rollingWindow: 7d
+    percentile: P90
+    safetyFactor: 1.2
 
   resourceBounds:
     cpu:
@@ -111,13 +119,10 @@ spec:
       min: 64Mi
       max: 4Gi
 
-  safetyConfig:
-    confidenceThreshold: high
-    maxChangePercent: 50
-    minUpdateInterval: 24h
-    memoryFloor: 64Mi
-    memoryHeadroom: 20%
-    enableRollback: true
+  updateStrategy:
+    strategy: webhook
+    rolloutStrategy: onNextRestart
+    updateRequestsOnly: true
 ```
 
 #### Step 2: Label Test Workload
@@ -159,11 +164,10 @@ If Phase 1 succeeded, expand gradually.
 #### Step 1: Update Policy Selector
 
 ```yaml
-targetWorkloads:
-  labelSelector:
+selector:
+  workloadSelector:
     matchLabels:
-      optipod.io/enabled: "true"
-      tier: "non-critical"
+      tier: non-critical
 ```
 
 #### Step 2: Label Additional Workloads
@@ -193,27 +197,26 @@ After 2+ weeks of successful Auto mode on non-critical workloads.
 #### Step 1: Create Production Policy
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: production-auto-policy
-  namespace: production
 spec:
   mode: Auto
-  updateStrategy: ServerSideApply
+  weight: 200  # Higher priority
 
-  targetWorkloads:
-    kinds:
-      - Deployment
-      - StatefulSet
-    labelSelector:
+  selector:
+    workloadSelector:
       matchLabels:
-        optipod.io/enabled: "true"
-        tier: "production"
+        tier: production
+    workloadTypes:
+      include: [Deployment, StatefulSet]
 
   metricsConfig:
     provider: prometheus
-    lookbackWindow: 14d  # Longer for production
+    rollingWindow: 14d  # Longer for production
+    percentile: P90
+    safetyFactor: 1.3   # More conservative
 
   resourceBounds:
     cpu:
@@ -223,17 +226,17 @@ spec:
       min: 128Mi
       max: 8Gi
 
-  safetyConfig:
-    confidenceThreshold: high
-    maxChangePercent: 25  # More conservative
-    minUpdateInterval: 48h  # Slower updates
-    memoryFloor: 128Mi
-    memoryHeadroom: 30%  # More headroom
-    enableRollback: true
-    rollbackTriggers:
-      - oomKills
-      - crashLoops
-      - highErrorRate
+  updateStrategy:
+    strategy: webhook
+    rolloutStrategy: onNextRestart  # Safer for production
+    updateRequestsOnly: true
+
+    # Gradual memory decreases for safety
+    gradualDecreaseConfig:
+      enabled: true
+      memoryDecreasePercentage: 10
+      minimumDecreaseThreshold: 100Mi
+      maximumTotalDecrease: 70
 ```
 
 #### Step 2: Gradual Rollout
@@ -260,7 +263,6 @@ Set up alerts for:
 - Pod restarts
 - High error rates
 - Latency increases
-- OptiPod rollbacks
 
 ### Phase 4: Critical Workloads
 
@@ -269,30 +271,44 @@ Only after months of successful Auto mode on production.
 #### Step 1: Extra Conservative Policy
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: critical-auto-policy
-  namespace: production
 spec:
   mode: Auto
-  updateStrategy: ServerSideApply
+  weight: 300  # Highest priority
 
-  targetWorkloads:
-    labelSelector:
+  selector:
+    workloadSelector:
       matchLabels:
-        tier: "critical"
+        tier: critical
 
   metricsConfig:
-    lookbackWindow: 30d  # Maximum stability
+    rollingWindow: 30d  # Maximum stability
+    percentile: P99     # Most conservative
+    safetyFactor: 1.5   # Extra headroom
 
-  safetyConfig:
-    confidenceThreshold: high
-    maxChangePercent: 15  # Very conservative
-    minUpdateInterval: 168h  # Weekly updates only
-    memoryFloor: 256Mi
-    memoryHeadroom: 50%  # Extra headroom
-    enableRollback: true
+  resourceBounds:
+    cpu:
+      min: 100m
+      max: 8000m
+    memory:
+      min: 256Mi
+      max: 16Gi
+
+  updateStrategy:
+    strategy: webhook
+    rolloutStrategy: onNextRestart
+    updateRequestsOnly: true
+
+    gradualDecreaseConfig:
+      enabled: true
+      memoryDecreasePercentage: 5   # Very gradual
+      minimumDecreaseThreshold: 200Mi
+      maximumTotalDecrease: 50      # Conservative limit
+
+  reconciliationInterval: 168h  # Weekly updates only
 ```
 
 #### Step 2: One at a Time
@@ -304,31 +320,29 @@ Enable Auto mode for critical workloads one at a time with weeks between each.
 ### Daily Checks
 
 ```bash
-# Check for any rollbacks
-kubectl get optimizationpolicy -A -o json | \
-  jq -r '.items[] | select(.status.rollbackCount > 0) |
-    "\(.metadata.namespace)/\(.metadata.name): \(.status.rollbackCount) rollbacks"'
-
 # Check for recent updates
-kubectl get deployments -A -l optipod.io/enabled=true \
-  -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.metadata.annotations.optipod\.io/last-applied}{"\n"}{end}'
+kubectl get deployments -A -o json | \
+  jq -r '.items[] | select(.metadata.annotations."optipod.io/managed" == "true") |
+    "\(.metadata.namespace)/\(.metadata.name): last-applied=\(.metadata.annotations."optipod.io/last-applied" // "never")"'
 
 # Check for OOM kills
 kubectl get events -A --field-selector reason=OOMKilled --sort-by='.lastTimestamp'
+
+# Check policy status
+kubectl get optimizationpolicy -A
 ```
 
 ### Weekly Review
 
 ```bash
-# Generate report of all Auto mode changes
-kubectl get events -A --field-selector involvedObject.kind=OptimizationPolicy | \
-  grep "Applied recommendation"
-
 # Review resource usage trends
-kubectl top pods -A -l optipod.io/enabled=true
+kubectl top pods -A -l optipod.io/managed=true
 
-# Check policy status
+# Check policy status details
 kubectl get optimizationpolicy -A -o yaml
+
+# Review controller logs for any issues
+kubectl logs -n optipod-system -l app=optipod-controller --tail=100
 ```
 
 ## Handling Issues
@@ -343,7 +357,12 @@ kubectl patch optimizationpolicy <policy-name> \
   --type merge \
   -p '{"spec":{"mode":"Disabled"}}'
 
-# Revert problematic workload
+# Or switch to Recommend mode
+kubectl patch optimizationpolicy <policy-name> \
+  --type merge \
+  -p '{"spec":{"mode":"Recommend"}}'
+
+# Revert problematic workload manually if needed
 kubectl set resources deployment <name> \
   --requests=cpu=<previous>,memory=<previous>
 ```
@@ -354,8 +373,8 @@ kubectl set resources deployment <name> \
 # Check what changed
 kubectl get deployment <name> -o yaml | grep optipod.io/
 
-# Review operator logs
-kubectl logs -n optipod-system -l app=optipod-operator --tail=500
+# Review controller logs
+kubectl logs -n optipod-system -l app=optipod-controller --tail=500
 
 # Check policy configuration
 kubectl get optimizationpolicy <policy-name> -o yaml
@@ -374,40 +393,47 @@ kubectl get optimizationpolicy <policy-name> -o yaml
 
 Solution:
 ```yaml
-safetyConfig:
-  memoryFloor: 256Mi  # Increase floor
-  memoryHeadroom: 40%  # Increase headroom
+resourceBounds:
+  memory:
+    min: 256Mi  # Increase minimum
+metricsConfig:
+  safetyFactor: 1.5  # Increase headroom
+updateStrategy:
+  gradualDecreaseConfig:
+    enabled: true
+    memoryDecreasePercentage: 5  # More gradual
 ```
 
 **Issue: Too Many Changes**
 
 Solution:
 ```yaml
-safetyConfig:
-  minUpdateInterval: 72h  # Slow down updates
-  maxChangePercent: 25  # Smaller changes
+reconciliationInterval: 72h  # Slow down updates
+metricsConfig:
+  rollingWindow: 14d  # Longer window for stability
 ```
 
-**Issue: Low Confidence Recommendations**
+**Issue: Recommendations Too Aggressive**
 
 Solution:
 ```yaml
 metricsConfig:
-  lookbackWindow: 21d  # Longer window
-safetyConfig:
-  confidenceThreshold: high  # Stricter threshold
+  percentile: P99      # More conservative
+  safetyFactor: 1.5    # More headroom
 ```
 
 ## Best Practices
 
 1. **Go slow**: Take months, not weeks
 2. **Monitor closely**: Especially in first few weeks
-3. **Start conservative**: Tighten safety settings initially
+3. **Start conservative**: Use higher safety factors and longer rolling windows initially
 4. **Document everything**: Track what works and what doesn't
 5. **Have rollback ready**: Know how to quickly disable
 6. **Communicate**: Inform team about Auto mode rollout
 7. **Review regularly**: Weekly review of Auto mode activity
 8. **Adjust policies**: Fine-tune based on experience
+9. **Use gradual decreases**: Enable gradual memory decrease for production workloads
+10. **Test update strategies**: Understand SSA vs webhook behavior in your environment
 
 ## Success Criteria
 
@@ -424,4 +450,4 @@ You've successfully transitioned to Auto mode when:
 
 - [Understand the safety model](/docs/concepts/safety-model)
 - [Learn about update strategies](/docs/concepts/update-strategies)
-- [Review troubleshooting guide](/docs/advanced/troubleshooting)
+- [Review operational modes](/docs/concepts/operational-modes)


### PR DESCRIPTION
## Phase 2: Reference Documentation Fixes

This PR completes Phase 2 of the documentation fix effort, correcting 4 reference documentation files with accurate information from the codebase.

### Files Fixed

1. **operational-modes.mdx** - Corrected mode descriptions and field names
2. **update-strategies.mdx** - Fixed strategy structure and GitOps integration details
3. **terminology.mdx** - Removed fabricated features, added actual ones
4. **switching-to-auto.mdx** - Updated with correct policy structure and safety features

### Key Corrections

**Field Names:**
- `targetWorkloads` → `selector`
- `lookbackWindow` → `rollingWindow`
- `kinds` → `workloadTypes.include`
- `labelSelector` → `workloadSelector`
- `updateStrategy` (string) → `updateStrategy` (object with `strategy` and `rolloutStrategy`)

**API Group:**
- `optipod.io/v1alpha1` → `optipod.optipod.io/v1alpha1`

**Annotation Format:**
- Changed from fabricated JSON blob to actual per-resource annotations:
  - `optipod.io/cpu-request.<container-name>`
  - `optipod.io/memory-request.<container-name>`
  - `optipod.io/cpu-limit.<container-name>`
  - `optipod.io/memory-limit.<container-name>`

**Removed Fabricated Features:**
- `safetyConfig` section
- `ssaConfig` section
- `webhookConfig` per-policy
- Confidence levels
- Impact estimation
- Rollback features

**Added Missing Features:**
- `weight` field
- `percentile` field
- `safetyFactor` field
- `gradualDecreaseConfig` in updateStrategy
- `limitConfig` in updateStrategy
- `allowUnsafeMemoryDecrease` in updateStrategy
- `updateRequestsOnly` in updateStrategy
- `allowInPlaceResize` in updateStrategy
- `allowRecreate` in updateStrategy

**Supported Workload Types:**
- Corrected to: Deployment, StatefulSet, DaemonSet only
- Removed: Job, CronJob (not supported)

### Verification

✅ Website build passes: `npm run build` successful
✅ All examples use correct field names
✅ All code blocks reference actual CRD structure
✅ Pre-commit hooks pass

### Related

- Follows Phase 1: #57
- Part of comprehensive documentation audit

### Statistics

- **Files changed:** 4
- **Lines changed:** +824 / -437
- **Build status:** ✅ Passing