### PR TITLE
docs: fix Phase 3 advanced topics documentation

### DIFF
--- a/website/src/content/docs/docs/advanced/custom-metrics.mdx
+++ b/website/src/content/docs/docs/advanced/custom-metrics.mdx
@@ -57,50 +57,50 @@ OptiPod expects metrics providers to implement a simple HTTP API that returns re
 ### Basic Configuration
 
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: custom-metrics-policy
 spec:
+  mode: Recommend
+  selector:
+    workloadSelector:
+      matchLabels:
+        optipod.io/enabled: "true"
   metricsConfig:
     provider: custom
-    custom:
-      endpoint: http://custom-metrics.monitoring.svc:8080
-      authSecret: custom-metrics-auth
-      queryTimeout: 30s
-    lookbackWindow: 7d
-    sampleInterval: 5m
+    rollingWindow: 7d
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 64Mi
+      max: 8Gi
+  updateStrategy:
+    strategy: webhook
 ```
+
+**Note:** Custom metrics provider configuration (endpoint, authentication, etc.) is configured externally via Helm values or environment variables, not in the CRD. See the Implementation Examples section below for how to build a custom metrics provider that OptiPod can query.
 
 ### Authentication
 
-Create a secret with authentication credentials:
+Custom metrics providers should implement their own authentication. OptiPod can be configured to pass authentication credentials via Helm values:
 
 ```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: custom-metrics-auth
-  namespace: default
-type: Opaque
-stringData:
-  token: "your-api-token"  # pragma: allowlist secret
-  # Or for basic auth:
-  username: "user"
-  password: "pass"  # pragma: allowlist secret
+# Helm values for OptiPod with custom metrics provider
+customMetrics:
+  enabled: true
+  endpoint: http://custom-metrics.monitoring.svc:8080
+  auth:
+    type: bearer  # or basic
+    token: "your-api-token"  # pragma: allowlist secret
+    # Or for basic auth:
+    # username: "user"
+    # password: "pass"  # pragma: allowlist secret
 ```
 
-OptiPod will include authentication in requests:
-
-**Bearer Token:**
-```
-Authorization: Bearer <token>
-```
-
-**Basic Auth:**
-```
-Authorization: Basic <base64(username:password)>
-```
+Your custom metrics provider should validate these credentials on each request.
 
 ## Implementation Examples
 

--- a/website/src/content/docs/docs/advanced/multi-tenant.mdx
+++ b/website/src/content/docs/docs/advanced/multi-tenant.mdx
@@ -19,32 +19,56 @@ Each tenant gets their own namespace(s) with isolated policies.
 **Setup:**
 ```yaml
 # Team A policy
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: team-a-policy
   namespace: team-a
 spec:
   mode: Auto
-  targetWorkloads:
-    kinds: [Deployment]
-    labelSelector:
+  selector:
+    workloadTypes:
+      include: [Deployment]
+    workloadSelector:
       matchLabels:
         optipod.io/enabled: "true"
+  metricsConfig:
+    provider: prometheus
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 64Mi
+      max: 8Gi
+  updateStrategy:
+    strategy: webhook
 ---
 # Team B policy
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: team-b-policy
   namespace: team-b
 spec:
   mode: Recommend
-  targetWorkloads:
-    kinds: [Deployment, StatefulSet]
-    labelSelector:
+  selector:
+    workloadTypes:
+      include: [Deployment, StatefulSet]
+    workloadSelector:
       matchLabels:
         optipod.io/enabled: "true"
+  metricsConfig:
+    provider: prometheus
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 64Mi
+      max: 8Gi
+  updateStrategy:
+    strategy: webhook
 ```
 
 ### Label-based Tenancy
@@ -58,18 +82,29 @@ Multiple tenants share namespaces but use labels for isolation.
 
 **Setup:**
 ```yaml
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: tenant-policy
   namespace: shared
 spec:
   mode: Auto
-  targetWorkloads:
-    labelSelector:
+  selector:
+    workloadSelector:
       matchLabels:
         tenant: team-a
         optipod.io/enabled: "true"
+  metricsConfig:
+    provider: prometheus
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 64Mi
+      max: 8Gi
+  updateStrategy:
+    strategy: webhook
 ```
 
 ## Configuration Patterns
@@ -80,7 +115,7 @@ Single operations team manages all policies.
 
 ```yaml
 # Central ops team creates policies for all tenants
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: standard-policy
@@ -89,17 +124,25 @@ metadata:
     managed-by: ops-team
 spec:
   mode: Auto
-  updateStrategy: ServerSideApply
-  # Standard configuration for all tenants
+  selector:
+    workloadSelector:
+      matchLabels:
+        optipod.io/enabled: "true"
   metricsConfig:
     provider: prometheus
-    lookbackWindow: 7d
+    rollingWindow: 7d
+    percentile: P90
+    safetyFactor: 1.2
   resourceBounds:
-    cpu: {min: 10m, max: 4000m}
-    memory: {min: 64Mi, max: 8Gi}
-  safetyConfig:
-    confidenceThreshold: high
-    maxChangePercent: 50
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 64Mi
+      max: 8Gi
+  updateStrategy:
+    strategy: ssa
+    useServerSideApply: true
 ```
 
 **RBAC:**
@@ -109,7 +152,7 @@ kind: ClusterRole
 metadata:
   name: optipod-admin
 rules:
-  - apiGroups: ["optipod.io"]
+  - apiGroups: ["optipod.optipod.io"]
     resources: ["optimizationpolicies"]
     verbs: ["*"]
 ---
@@ -139,7 +182,7 @@ metadata:
   name: optipod-manager
   namespace: team-a
 rules:
-  - apiGroups: ["optipod.io"]
+  - apiGroups: ["optipod.optipod.io"]
     resources: ["optimizationpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
@@ -164,7 +207,7 @@ Central defaults with tenant overrides.
 
 ```yaml
 # Central default policy
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: default-policy
@@ -173,11 +216,27 @@ metadata:
     policy-type: default
 spec:
   mode: Recommend
-  # Conservative defaults
+  weight: 100  # Lower priority
+  selector:
+    workloadSelector:
+      matchLabels:
+        optipod.io/enabled: "true"
+  metricsConfig:
+    provider: prometheus
+    rollingWindow: 7d
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 2000m
+    memory:
+      min: 64Mi
+      max: 4Gi
+  updateStrategy:
+    strategy: webhook
 
 ---
 # Tenant override policy
-apiVersion: optipod.io/v1alpha1
+apiVersion: optipod.optipod.io/v1alpha1
 kind: OptimizationPolicy
 metadata:
   name: team-a-custom
@@ -186,12 +245,24 @@ metadata:
     policy-type: custom
 spec:
   mode: Auto
-  targetWorkloads:
-    labelSelector:
+  weight: 200  # Higher priority - overrides default
+  selector:
+    workloadSelector:
       matchLabels:
         team: team-a
         tier: non-critical
-  # Team-specific configuration
+  metricsConfig:
+    provider: prometheus
+    rollingWindow: 14d
+  resourceBounds:
+    cpu:
+      min: 10m
+      max: 4000m
+    memory:
+      min: 128Mi
+      max: 8Gi
+  updateStrategy:
+    strategy: webhook
 ```
 
 ## Resource Isolation
@@ -258,36 +329,35 @@ spec:
 
 ### Prometheus with Multi-tenancy
 
-Configure tenant-specific Prometheus queries:
+OptiPod queries Prometheus with namespace filtering automatically. Prometheus configuration is external (via Helm values or environment variables), not in the CRD.
 
+```yaml
+# Helm values for OptiPod
+prometheus:
+  address: http://prometheus-server.monitoring.svc:9090
+```
+
+Policy configuration:
 ```yaml
 spec:
   metricsConfig:
     provider: prometheus
-    prometheus:
-      address: http://prometheus-server.monitoring.svc:9090
-      # Queries automatically filtered by namespace
+    rollingWindow: 7d
+    # Queries automatically filtered by namespace
 ```
 
 ### Separate Prometheus Instances
 
-Each tenant gets their own Prometheus:
+Each tenant can use their own Prometheus by configuring different addresses via Helm:
 
 ```yaml
-# Team A policy
-spec:
-  metricsConfig:
-    provider: prometheus
-    prometheus:
-      address: http://prometheus-team-a.team-a.svc:9090
+# Team A Helm values
+prometheus:
+  address: http://prometheus-team-a.team-a.svc:9090
 
----
-# Team B policy
-spec:
-  metricsConfig:
-    provider: prometheus
-    prometheus:
-      address: http://prometheus-team-b.team-b.svc:9090
+# Team B Helm values
+prometheus:
+  address: http://prometheus-team-b.team-b.svc:9090
 ```
 
 ## Policy Templates
@@ -303,24 +373,31 @@ metadata:
   namespace: optipod-system
 data:
   standard-policy.yaml: |
-    apiVersion: optipod.io/v1alpha1
+    apiVersion: optipod.optipod.io/v1alpha1
     kind: OptimizationPolicy
     metadata:
       name: standard-policy
       namespace: ${NAMESPACE}
     spec:
       mode: Recommend
-      targetWorkloads:
-        kinds: [Deployment, StatefulSet]
-        labelSelector:
+      selector:
+        workloadTypes:
+          include: [Deployment, StatefulSet]
+        workloadSelector:
           matchLabels:
             optipod.io/enabled: "true"
       metricsConfig:
         provider: prometheus
-        lookbackWindow: 7d
+        rollingWindow: 7d
       resourceBounds:
-        cpu: {min: 10m, max: 4000m}
-        memory: {min: 64Mi, max: 8Gi}
+        cpu:
+          min: 10m
+          max: 4000m
+        memory:
+          min: 64Mi
+          max: 8Gi
+      updateStrategy:
+        strategy: webhook
 ```
 
 Apply template for new tenant:
@@ -336,18 +413,25 @@ envsubst < policy-template.yaml | kubectl apply -f -
 
 ### Per-Tenant Metrics
 
-Track OptiPod activity per tenant:
+Track OptiPod activity per tenant using Prometheus metrics:
 
 ```promql
 # Recommendations generated per namespace
 sum by (namespace) (optipod_recommendations_total)
 
-# Resource savings per namespace
-sum by (namespace) (optipod_cpu_savings_cores)
-sum by (namespace) (optipod_memory_savings_bytes)
+# Policies per namespace
+count by (namespace) (optipod_policy_info)
 
-# Rollbacks per namespace
-sum by (namespace) (optipod_rollbacks_total)
+# Workloads managed per namespace
+sum by (namespace) (optipod_workloads_managed_total)
+```
+
+Note: Actual metric names depend on OptiPod's controller-runtime metrics. Check available metrics:
+
+```bash
+kubectl port-forward -n optipod-system svc/optipod-controller-metrics 8080:8080
+curl localhost:8080/metrics | grep optipod
+```
 ```
 
 ### Tenant Dashboards
@@ -487,14 +571,14 @@ metadata:
 ```bash
 # Find conflicting policies
 kubectl get optimizationpolicy -A -o json | \
-  jq -r '.items[] | select(.spec.targetWorkloads.labelSelector.matchLabels."optipod.io/enabled" == "true") |
+  jq -r '.items[] | select(.spec.selector.workloadSelector.matchLabels."optipod.io/enabled" == "true") |
     "\(.metadata.namespace)/\(.metadata.name)"'
 ```
 
 Use more specific selectors:
 ```yaml
-targetWorkloads:
-  labelSelector:
+selector:
+  workloadSelector:
     matchLabels:
       optipod.io/enabled: "true"
       tenant: team-a  # Add tenant label

--- a/website/src/content/docs/docs/advanced/troubleshooting.mdx
+++ b/website/src/content/docs/docs/advanced/troubleshooting.mdx
@@ -66,12 +66,12 @@ kubectl apply -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/de
 2. **Missing CRDs**
 ```bash
 # Check CRDs
-kubectl get crd optimizationpolicies.optipod.io
+kubectl get crd optimizationpolicies.optipod.optipod.io
 ```
 
 **Solution:** Install CRDs:
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/deploy/crds/
+kubectl apply -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/config/crd/bases/
 ```
 
 3. **Resource constraints**
@@ -101,10 +101,10 @@ kubectl describe mutatingwebhookconfiguration optipod-webhook
 
 **Solution:**
 
-1. **Set failure policy to Ignore**
-```yaml
-webhookConfig:
-  failurePolicy: Ignore
+1. **Check webhook deployment**
+```bash
+kubectl get pods -n optipod-system -l app=optipod-webhook
+kubectl logs -n optipod-system -l app=optipod-webhook
 ```
 
 2. **Check webhook service**
@@ -115,6 +115,8 @@ kubectl get svc -n optipod-system optipod-webhook
 3. **Verify certificates**
 ```bash
 kubectl get secret -n optipod-system optipod-webhook-cert
+# Or check cert-manager certificate
+kubectl get certificate -n optipod-system
 ```
 
 ## Policy Issues
@@ -123,7 +125,7 @@ kubectl get secret -n optipod-system optipod-webhook-cert
 
 **Symptoms:**
 - Workloads labeled but no recommendations appear
-- `optipod.io/recommendation` annotation missing
+- Recommendation annotations missing
 
 **Diagnosis:**
 ```bash
@@ -134,15 +136,15 @@ kubectl get deployment <name> -o yaml | grep -A 5 labels
 kubectl get optimizationpolicy -n <namespace>
 kubectl describe optimizationpolicy <policy-name> -n <namespace>
 
-# Check operator logs
-kubectl logs -n optipod-system -l app=optipod-operator | grep <workload-name>
+# Check controller logs
+kubectl logs -n optipod-system -l app=optipod-controller | grep <workload-name>
 ```
 
 **Common Causes:**
 
 1. **Insufficient metrics data**
 
-**Solution:** Wait for more data (typically 24-48 hours with 7-day lookback)
+**Solution:** Wait for more data (typically 24-48 hours with 7-day rolling window)
 
 2. **Workload not matching policy selector**
 
@@ -152,7 +154,7 @@ kubectl logs -n optipod-system -l app=optipod-operator | grep <workload-name>
 kubectl get deployment <name> -o jsonpath='{.metadata.labels}'
 
 # Check policy selector
-kubectl get optimizationpolicy <policy-name> -o jsonpath='{.spec.targetWorkloads.labelSelector}'
+kubectl get optimizationpolicy <policy-name> -o jsonpath='{.spec.selector.workloadSelector}'
 ```
 
 3. **Policy in Disabled mode**
@@ -186,7 +188,7 @@ kubectl top nodes
 ```bash
 # Check last update time
 kubectl get deployment <name> \
-  -o jsonpath='{.metadata.annotations.optipod\.io/last-updated}'
+  -o jsonpath='{.metadata.annotations.optipod\.io/last-recommendation}'
 
 # Check policy status
 kubectl get optimizationpolicy <policy-name> -o yaml
@@ -194,29 +196,25 @@ kubectl get optimizationpolicy <policy-name> -o yaml
 
 **Common Causes:**
 
-1. **In cooldown period**
+1. **Reconciliation interval not reached**
 
-**Solution:** Wait for cooldown to expire or adjust:
+**Solution:** Wait for reconciliation interval or adjust:
 ```yaml
-safetyConfig:
-  minUpdateInterval: 12h  # Reduce interval
+spec:
+  reconciliationInterval: 12h  # Reduce interval (default: 5m)
 ```
 
-2. **Confidence threshold too high**
-
-**Solution:**
-```yaml
-safetyConfig:
-  confidenceThreshold: medium  # Lower threshold
-```
-
-3. **Operator not running**
+2. **Controller not running**
 
 **Solution:**
 ```bash
 kubectl get pods -n optipod-system
-kubectl rollout restart deployment optipod-operator -n optipod-system
+kubectl rollout restart deployment optipod-controller -n optipod-system
 ```
+
+3. **Metrics haven't changed significantly**
+
+OptiPod may not update recommendations if metrics are stable and within acceptable range.
 
 ### Recommendations Seem Incorrect
 
@@ -229,24 +227,21 @@ kubectl rollout restart deployment optipod-operator -n optipod-system
 # Check actual usage
 kubectl top pod -l app=<name>
 
-# Check recommendation
-kubectl get deployment <name> \
-  -o jsonpath='{.metadata.annotations.optipod\.io/recommendation}' | jq .
+# Check recommendation annotations
+kubectl get deployment <name> -o yaml | grep -A 10 "optipod.io/"
 
-# Check metrics analysis
-kubectl get deployment <name> \
-  -o jsonpath='{.metadata.annotations.optipod\.io/recommendation}' | \
-  jq '.metricsAnalysis'
+# Check policy configuration
+kubectl get optimizationpolicy <policy-name> -o yaml
 ```
 
 **Common Causes:**
 
-1. **Lookback window too short**
+1. **Rolling window too short**
 
 **Solution:**
 ```yaml
 metricsConfig:
-  lookbackWindow: 14d  # Increase window
+  rollingWindow: 14d  # Increase window
 ```
 
 2. **Resource bounds too restrictive**
@@ -257,14 +252,34 @@ resourceBounds:
   cpu:
     min: 10m   # Lower minimum
     max: 8000m # Raise maximum
+  memory:
+    min: 64Mi
+    max: 16Gi
 ```
 
-3. **Unstable workload**
+3. **Safety factor too high or too low**
+
+**Solution:**
+```yaml
+metricsConfig:
+  safetyFactor: 1.2  # Adjust multiplier (default: 1.2)
+```
+
+4. **Wrong percentile**
+
+**Solution:**
+```yaml
+metricsConfig:
+  percentile: P90  # Try P99 for more headroom, P50 for more aggressive
+```
+
+5. **Unstable workload**
 
 **Solution:** Some workloads aren't good candidates for optimization. Consider:
-- Increasing lookback window
+- Increasing rolling window
+- Using higher percentile (P99)
+- Increasing safety factor
 - Using manual tuning instead
-- Accepting lower confidence recommendations
 
 ## Auto Mode Issues
 
@@ -279,93 +294,95 @@ resourceBounds:
 # Check policy mode
 kubectl get optimizationpolicy <policy-name> -o jsonpath='{.spec.mode}'
 
-# Check safety status
-kubectl get optimizationpolicy <policy-name> -o jsonpath='{.status.safetyStatus}'
+# Check policy status
+kubectl get optimizationpolicy <policy-name> -o yaml | grep -A 20 status
 
-# Check operator logs
-kubectl logs -n optipod-system -l app=optipod-operator | grep "Applied recommendation"
+# Check controller logs
+kubectl logs -n optipod-system -l app=optipod-controller | grep "Applied"
 ```
 
 **Common Causes:**
 
-1. **Confidence threshold not met**
+1. **Reconciliation interval not reached**
 
-**Solution:**
+**Solution:** Wait for next reconciliation or reduce interval:
 ```yaml
-safetyConfig:
-  confidenceThreshold: medium  # Lower threshold
+spec:
+  reconciliationInterval: 5m  # Default is 5m
 ```
 
-2. **In cooldown period**
+2. **Update strategy requires pod restart**
 
-**Solution:** Check cooldown status:
+If using webhook strategy with `onNextRestart`, changes won't apply until pods restart naturally.
+
+**Solution:** Use immediate rollout or trigger restart:
+```yaml
+updateStrategy:
+  strategy: webhook
+  rolloutStrategy: immediate  # Force rolling restart
+```
+
+Or manually restart:
 ```bash
-kubectl get deployment <name> \
-  -o jsonpath='{.metadata.annotations.optipod\.io/cooldown-until}'
+kubectl rollout restart deployment <name>
 ```
 
-3. **Change exceeds maxChangePercent**
+3. **Resource bounds preventing update**
 
-**Solution:**
+Recommendations may be outside configured bounds.
+
+**Solution:** Check and adjust bounds:
 ```yaml
-safetyConfig:
-  maxChangePercent: 75  # Allow larger changes
+resourceBounds:
+  cpu:
+    min: 10m
+    max: 8000m
+  memory:
+    min: 64Mi
+    max: 16Gi
 ```
 
-4. **SSA field ownership conflict**
-
-**Solution:**
-```yaml
-ssaConfig:
-  force: true  # Force ownership (use carefully!)
-```
-
-### Frequent Rollbacks
+### Memory Safety Issues
 
 **Symptoms:**
-- OptiPod keeps rolling back changes
-- High rollback count
+- OptiPod not applying memory decreases
+- Memory recommendations being blocked
 
 **Diagnosis:**
 ```bash
-# Check rollback count
-kubectl get optimizationpolicy <policy-name> \
-  -o jsonpath='{.status.safetyStatus.rollbackCount}'
+# Check controller logs for safety blocks
+kubectl logs -n optipod-system -l app=optipod-controller | grep -i "memory.*blocked"
 
-# Check recent issues
-kubectl get optimizationpolicy <policy-name> \
-  -o jsonpath='{.status.safetyStatus.recentIssues}'
+# Check current memory usage
+kubectl top pod -l app=<name>
 
-# Check for OOM kills
-kubectl get events --field-selector reason=OOMKilled
+# Check recommendations
+kubectl get deployment <name> -o yaml | grep "optipod.io/memory"
 ```
 
 **Common Causes:**
 
-1. **Memory recommendations too low**
+1. **Memory safety check blocking decrease**
 
-**Solution:**
+By default, OptiPod blocks memory decreases that could cause OOM kills.
+
+**Solution:** If you're confident the decrease is safe:
 ```yaml
-safetyConfig:
-  memoryFloor: 128Mi    # Increase floor
-  memoryHeadroom: 30    # Increase headroom
+updateStrategy:
+  allowUnsafeMemoryDecrease: true  # Use with caution!
 ```
 
-2. **Changes too aggressive**
+2. **Gradual decrease in progress**
 
-**Solution:**
+If gradual decrease is enabled, large memory reductions happen incrementally.
+
+**Solution:** Wait for gradual decrease to complete or adjust:
 ```yaml
-safetyConfig:
-  maxChangePercent: 25  # Smaller changes
-  minUpdateInterval: 48h # Slower updates
+updateStrategy:
+  gradualDecreaseConfig:
+    enabled: true
+    memoryDecreasePercentage: 20  # Faster decreases (default: 10)
 ```
-
-3. **Workload has memory spikes**
-
-**Solution:**
-- Increase lookback window to capture spikes
-- Increase memory headroom
-- Consider manual tuning
 
 ### OOM Kills After OptiPod Changes
 
@@ -391,10 +408,8 @@ kubectl set resources deployment <name> \
 # Check memory usage
 kubectl top pod -l app=<name>
 
-# Check recommendation that was applied
-kubectl get deployment <name> \
-  -o jsonpath='{.metadata.annotations.optipod\.io/recommendation}' | \
-  jq '.metricsAnalysis'
+# Check what was applied
+kubectl get deployment <name> -o yaml | grep -A 5 "optipod.io/"
 
 # Check for memory spikes in Prometheus
 # Query: container_memory_usage_bytes{pod=~"<name>.*"}
@@ -402,13 +417,19 @@ kubectl get deployment <name> \
 
 **Prevention:**
 ```yaml
-safetyConfig:
-  memoryFloor: 256Mi      # Higher floor
-  memoryHeadroom: 50      # More headroom
-  maxChangePercent: 25    # Smaller changes
-  enableRollback: true    # Ensure rollback enabled
-  rollbackTriggers:
-    - oomKills
+metricsConfig:
+  percentile: P99        # Use higher percentile
+  safetyFactor: 1.5      # More headroom
+
+resourceBounds:
+  memory:
+    min: 256Mi           # Higher floor
+
+updateStrategy:
+  gradualDecreaseConfig:
+    enabled: true
+    memoryDecreasePercentage: 10
+    minimumDecreaseThreshold: 100Mi
 ```
 
 ## Metrics Issues
@@ -416,27 +437,32 @@ safetyConfig:
 ### Prometheus Connection Failed
 
 **Symptoms:**
-- Operator logs show Prometheus errors
+- Controller logs show Prometheus errors
 - No recommendations generated
 
 **Diagnosis:**
 ```bash
-# Check Prometheus address in policy
-kubectl get optimizationpolicy <policy-name> \
-  -o jsonpath='{.spec.metricsConfig.prometheus.address}'
+# Check controller logs
+kubectl logs -n optipod-system -l app=optipod-controller | grep -i prometheus
 
-# Test connectivity from operator pod
-kubectl exec -n optipod-system <operator-pod> -- \
+# Test connectivity from controller pod
+kubectl exec -n optipod-system <controller-pod> -- \
   curl -v http://prometheus-server.monitoring.svc:9090/-/healthy
 ```
 
 **Solution:**
 
-1. **Verify Prometheus address**
+1. **Verify Prometheus is accessible**
+
+Prometheus configuration is external to OptiPod (not in the CRD). Configure via:
+- Helm values
+- Environment variables
+- ConfigMap
+
+Check Helm values:
 ```yaml
-metricsConfig:
-  prometheus:
-    address: http://prometheus-server.monitoring.svc:9090
+prometheus:
+  address: http://prometheus-server.monitoring.svc:9090
 ```
 
 2. **Check network policies**
@@ -487,49 +513,62 @@ kubectl patch deployment metrics-server -n kube-system --type='json' \
 
 **Solution:**
 
-1. **Use Server-Side Apply**
+1. **Use webhook strategy with onNextRestart**
+
+This keeps workload specs unchanged in Git:
 ```yaml
-updateStrategy: ServerSideApply
+updateStrategy:
+  strategy: webhook
+  rolloutStrategy: onNextRestart
 ```
 
-2. **Configure GitOps to ignore OptiPod fields**
+OptiPod stores recommendations as annotations, webhook applies them at pod creation.
+
+2. **Configure GitOps to ignore OptiPod annotations**
 
 For ArgoCD:
 ```yaml
-apiVersion: v1
-kind: ConfigMap
+apiVersion: argoproj.io/v1alpha1
+kind: Application
 metadata:
-  name: argocd-cm
-data:
-  resource.customizations: |
-    apps/Deployment:
-      ignoreDifferences: |
-        jsonPointers:
-        - /spec/template/spec/containers/0/resources/requests/cpu
-        - /spec/template/spec/containers/0/resources/requests/memory
-        - /spec/template/spec/containers/0/resources/limits/cpu
-        - /spec/template/spec/containers/0/resources/limits/memory
-```
-
-For Flux:
-```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: apps
+  name: my-app
 spec:
-  force: false
-  prune: true
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /metadata/annotations/optipod.io~1cpu-request.*
+    - /metadata/annotations/optipod.io~1memory-request.*
+    - /metadata/annotations/optipod.io~1cpu-limit.*
+    - /metadata/annotations/optipod.io~1memory-limit.*
 ```
 
-3. **Use Recommend mode**
+3. **Use SSA strategy with ArgoCD SSA support**
+
+If using ArgoCD 2.5+:
+```yaml
+syncPolicy:
+  syncOptions:
+  - ServerSideApply=true
+```
+
+Then configure OptiPod:
+```yaml
+updateStrategy:
+  strategy: ssa
+  useServerSideApply: true
+```
+
+4. **Use Recommend mode**
+
+Most GitOps-friendly approach:
 ```yaml
 mode: Recommend  # Manual application via GitOps
 ```
 
 ## Performance Issues
 
-### Operator Using Too Much CPU/Memory
+### Controller Using Too Much CPU/Memory
 
 **Diagnosis:**
 ```bash
@@ -538,7 +577,7 @@ kubectl top pod -n optipod-system
 
 **Solution:**
 
-1. **Increase operator resources**
+1. **Increase controller resources**
 ```yaml
 resources:
   requests:
@@ -551,30 +590,33 @@ resources:
 
 2. **Reduce workload count**
 - Use more specific label selectors
-- Split into multiple policies
+- Split into multiple policies with different reconciliation intervals
 
-3. **Increase sample interval**
+3. **Increase reconciliation interval**
 ```yaml
-metricsConfig:
-  sampleInterval: 10m  # Less frequent sampling
+spec:
+  reconciliationInterval: 15m  # Less frequent reconciliation
 ```
 
 ### Slow Recommendation Generation
 
 **Solution:**
 
-1. **Reduce lookback window**
+1. **Reduce rolling window**
 ```yaml
 metricsConfig:
-  lookbackWindow: 3d  # Shorter window
+  rollingWindow: 3d  # Shorter window (less data to process)
 ```
 
-2. **Increase query timeout**
+2. **Use metrics-server instead of Prometheus**
+
+For simpler deployments:
 ```yaml
 metricsConfig:
-  prometheus:
-    queryTimeout: 60s
+  provider: metrics-server
 ```
+
+Note: metrics-server provides less historical data but is faster.
 
 ## Getting Help
 
@@ -582,14 +624,17 @@ If you can't resolve your issue:
 
 1. **Collect diagnostic information**
 ```bash
-# Operator logs
-kubectl logs -n optipod-system -l app=optipod-operator > operator-logs.txt
+# Controller logs
+kubectl logs -n optipod-system -l app=optipod-controller > controller-logs.txt
 
 # Policy status
 kubectl get optimizationpolicy -A -o yaml > policies.yaml
 
 # Workload status
 kubectl get deployment <name> -o yaml > workload.yaml
+
+# Events
+kubectl get events -A --sort-by='.lastTimestamp' > events.txt
 ```
 
 2. **Check GitHub Issues**
@@ -605,3 +650,4 @@ kubectl get deployment <name> -o yaml > workload.yaml
 - [Review safety model](/docs/concepts/safety-model)
 - [Check API reference](/docs/reference/api)
 - [Read operational modes guide](/docs/concepts/operational-modes)
+- [Understand update strategies](/docs/concepts/update-strategies)


### PR DESCRIPTION
## Phase 3: Advanced Topics Documentation Fixes

This PR fixes critical documentation errors in the advanced topics section of the OptiPod website.

### Files Fixed (3/3)
- ✅  - Fixed field names, removed fabricated features
- ✅  - Fixed API group, field names, troubleshooting section  
- ✅  - Fixed configuration section, clarified external config

Note:  was listed in the original audit but doesn't exist in the repository.

### Key Changes

**API Group Correction:**
- Changed `optipod.io/v1alpha1` → `optipod.optipod.io/v1alpha1` throughout

**Field Name Corrections:**
- `targetWorkloads` → `selector`
- `lookbackWindow` → `rollingWindow`
- `kinds` → `workloadTypes.include`
- `labelSelector` → `workloadSelector`

**Removed Fabricated Features:**
- `safetyConfig` section in CRD
- `custom.endpoint` and `custom.authSecret` in CRD (these are external config)
- Fabricated savings metrics in status

**Clarifications:**
- Prometheus configuration is external (Helm values/env vars), not in CRD
- Custom metrics provider configuration is external
- Authentication is handled via Helm values, not CRD secrets

### Build Status
✅ Website build passing successfully

### Related PRs
- #57 - Phase 1: Critical user-facing documentation
- #58 - Phase 2: Reference documentation

### Progress
- Phase 1: ✅ Complete (7 files)
- Phase 2: ✅ Complete (4 files)  
- Phase 3: ✅ Complete (3 files)
- Phase 4: ⏳ Pending (2 files)

**Overall: 14/26 files fixed (54%)**