### PR TITLE
docs: fix Phase 4 introductory documentation

### DIFF
--- a/website/src/content/docs/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/docs/getting-started/installation.mdx
@@ -40,20 +40,23 @@ You can customize the installation with a values file:
 
 ```yaml
 # values.yaml
-replicaCount: 2
+controller:
+  replicaCount: 2
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
-
-metricsProvider:
-  type: prometheus
-  prometheus:
-    address: http://prometheus-server.monitoring.svc:9090
+# Prometheus configuration (if using Prometheus)
+prometheus:
+  address: http://prometheus-server.monitoring.svc:9090
+  # Optional: Configure authentication
+  # auth:
+  #   type: bearer
+  #   token: "your-token"
 ```
 
 Install with custom values:
@@ -74,13 +77,15 @@ You can also install OptiPod directly using kubectl:
 
 ```bash
 # Install CRDs
-kubectl apply -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/deploy/crds/optimizationpolicy.yaml
+kubectl apply -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/config/crd/bases/optipod.optipod.io_optimizationpolicies.yaml
 
-# Install OptiPod operator
-kubectl apply -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/deploy/operator.yaml
+# Install OptiPod operator (use Helm for production)
+kubectl apply -k https://github.com/Sagart-cactus/optipod/config/default
 ```
 
-This will create the `optipod-system` namespace, install the OptimizationPolicy CRD, deploy the OptiPod operator, and create necessary RBAC resources.
+:::note
+For production deployments, we recommend using Helm for easier configuration and upgrades.
+:::
 
   </TabItem>
   <TabItem label="Automated Script">
@@ -121,51 +126,57 @@ kubectl logs -n optipod-system -l app=optipod-operator
 
 ## Configure Metrics Provider
 
-OptiPod needs access to metrics to make recommendations. Configure your metrics provider:
+OptiPod needs access to metrics to make recommendations. Configure your metrics provider via Helm values:
 
 <Tabs>
   <TabItem label="Prometheus">
 
 ### Prometheus Configuration
 
-If using Prometheus, create a ConfigMap with the Prometheus address:
+Configure Prometheus in your Helm values:
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: optipod-config
-  namespace: optipod-system
-data:
-  metrics-provider: prometheus
-  prometheus-address: http://prometheus-server.monitoring.svc:9090
+# values.yaml
+prometheus:
+  address: http://prometheus-server.monitoring.svc:9090
+
+  # Optional: Configure authentication
+  auth:
+    type: bearer  # or "basic"
+    token: "your-prometheus-token"  # pragma: allowlist secret
+    # For basic auth:
+    # username: "user"
+    # password: "pass"  # pragma: allowlist secret
 ```
 
-Apply the configuration:
+Install with Prometheus configuration:
 
 ```bash
-kubectl apply -f prometheus-config.yaml
+helm install optipod optipod/optipod \
+  --namespace optipod-system \
+  --create-namespace \
+  -f values.yaml
 ```
+
+See the [Prometheus Setup Guide](/docs/prometheus-setup) for detailed configuration options.
 
   </TabItem>
   <TabItem label="metrics-server">
 
 ### metrics-server Configuration
 
-If using metrics-server, OptiPod will auto-detect it:
+OptiPod can use metrics-server for basic CPU and memory metrics:
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: optipod-config
-  namespace: optipod-system
-data:
-  metrics-provider: metrics-server
+# values.yaml
+metricsServer:
+  enabled: true
+  # Optional: Configure sampling
+  minSamplesRequired: 10
 ```
 
 :::note
-metrics-server provides basic CPU and memory metrics. For more detailed recommendations, consider using Prometheus.
+metrics-server provides basic CPU and memory metrics. For more detailed recommendations and historical data, consider using Prometheus.
 :::
 
   </TabItem>
@@ -204,8 +215,9 @@ kubectl delete namespace optipod-system
   <TabItem label="kubectl">
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/deploy/operator.yaml
-kubectl delete -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/deploy/crds/optimizationpolicy.yaml
+# Delete CRDs and resources
+kubectl delete -k https://github.com/Sagart-cactus/optipod/config/default
+kubectl delete -f https://raw.githubusercontent.com/Sagart-cactus/optipod/main/config/crd/bases/optipod.optipod.io_optimizationpolicies.yaml
 ```
 
   </TabItem>

--- a/website/src/content/docs/docs/getting-started/introduction.mdx
+++ b/website/src/content/docs/docs/getting-started/introduction.mdx
@@ -28,7 +28,7 @@ OptiPod solves these problems by providing **safe, explainable, and GitOps-frien
 | Recommend-only mode | ✅ Yes | ✅ Yes |
 | Auto-apply mode | ✅ With safeguards | ✅ Yes |
 | Update strategy options | ✅ Webhook or SSA | ⚠️ Webhook only |
-| Impact estimation | ✅ Yes | ❌ No |
+| Memory safety guardrails | ✅ Yes | ⚠️ Basic |
 
 ## How It Works
 
@@ -65,8 +65,8 @@ OptiPod is designed with safety as a top priority:
 - **Conservative defaults**: Never reduce memory below safe thresholds
 - **Policy-driven controls**: You define bounds and change limits
 - **Memory safeguards**: Prevents OOM kills from aggressive reductions
-- **Change-rate limits**: Prevents rapid oscillation
-- **Impact estimation**: Shows expected impact before changes
+- **Gradual decrease options**: Incremental memory reduction for safety
+- **Configurable safety factors**: Apply multipliers to recommendations
 
 ## Next Steps
 


### PR DESCRIPTION
## Phase 4: Introductory Documentation Fixes

This PR fixes critical documentation errors in the introductory/getting-started section of the OptiPod website.

### Files Fixed (2/2)
- ✅ `introduction.mdx` - Removed fabricated impact estimation feature
- ✅ `installation.mdx` - Fixed file paths, removed ConfigMap approach, corrected Helm values

### Key Changes

**Removed Fabricated Features:**
- Removed "Impact estimation" from VPA comparison table (feature doesn't exist in code)
- Removed "Change-rate limits" from safety model (not implemented)
- Removed ConfigMap-based configuration approach (not how OptiPod works)

**Fixed File Paths:**
- kubectl installation now uses correct CRD path: `config/crd/bases/optipod.optipod.io_optimizationpolicies.yaml`
- Updated to use kustomize for kubectl installation: `kubectl apply -k`
- Fixed uninstallation commands with correct paths

**Corrected Helm Values:**
- Removed fabricated `metricsProvider.type` and `metricsProvider.prometheus` structure
- Updated to actual Helm chart structure: `controller.resources`, `prometheus.address`
- Clarified metrics provider configuration via Helm values (not ConfigMap)
- Added proper authentication examples with pragma comments

**Updated Safety Model:**
- Replaced fabricated features with actual ones:
  - Gradual decrease options
  - Configurable safety factors
  - Memory safety guardrails

### Build Status
✅ Website build passing successfully

### Related PRs
- #57 - Phase 1: Critical user-facing documentation
- #58 - Phase 2: Reference documentation
- #59 - Phase 3: Advanced topics

### Progress
- Phase 1: ✅ Complete (7 files)
- Phase 2: ✅ Complete (4 files)
- Phase 3: ✅ Complete (3 files)
- Phase 4: ✅ Complete (2 files)

**Overall: 16/26 files fixed (62% - 1 file doesn't exist)**

All phases complete! 🎉